### PR TITLE
fixed too strict dataset sampling restriction

### DIFF
--- a/train.py
+++ b/train.py
@@ -79,9 +79,7 @@ class Sampler(object):
             self.boundaries.append(self.boundaries[-1] + chunks[i].shape[0])
 
     def sample(self, length):
-        assert length < self.total_size // len(
-            self.chunks
-        ), "Dataset files are too small to sample {} tokens at a time".format(length)
+        assert length < self.total_size, "Dataset files are too small to sample {} tokens at a time".format(length)
         while True:
             index = random.randint(0, self.total_size - length - 1)
             i = binary_search(lambda j: self.boundaries[j] > index, 0,


### PR DESCRIPTION
I am uncertain, if `// len(self.chunks)` was in `assert length < self.total_size // len(self.chunks)` to ensure, that samples will not span multiple entries too often.

Unless that's the case, it seems like it is just a guard against the second parameter in `random.randint(0, self.total_size - length - 1)` being < 0, in which case it is incorrect and too restrictive.

BTW, can you enable issue tracking on this repository? Does not seem like OpenAI is open for pull requests for training/tuning.