### PR TITLE
Add toposort to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fire>=0.1.3
 regex==2017.4.5
 requests==2.21.0
 tqdm==4.31.1
+toposort==1.5


### PR DESCRIPTION
We need toposort in requirements due to its use in memory_saving_gradients