### PR TITLE
Edit encoding

### DIFF
--- a/src/load_dataset.py
+++ b/src/load_dataset.py
@@ -29,7 +29,7 @@ def load_dataset(enc, path, combine):
                     token_chunks.append(npz[item])
         else:
             # Plain text
-            with open(path, 'r') as fp:
+            with open(path, 'r', encoding='utf8') as fp:
                 raw_text += fp.read()
             if len(raw_text) >= combine:
                 tokens = np.stack(enc.encode(raw_text))


### PR DESCRIPTION
If you do not have utf-8 encoding when you are training in a foreign language, you will get an error.